### PR TITLE
Add Helm chart for hourly feature reaper

### DIFF
--- a/charts/feature-reaper/.helmignore
+++ b/charts/feature-reaper/.helmignore
@@ -1,0 +1,5 @@
+# Patterns to ignore when packaging Helm charts.
+*.tgz
+*.tar.gz
+*.swp
+.DS_Store

--- a/charts/feature-reaper/Chart.yaml
+++ b/charts/feature-reaper/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: feature-reaper
+description: A Helm chart for scheduling the feature reaper CronJob
+version: 0.1.0
+appVersion: "1.0"

--- a/charts/feature-reaper/README.md
+++ b/charts/feature-reaper/README.md
@@ -1,0 +1,18 @@
+# Feature Reaper Helm Chart
+
+This chart deploys a Kubernetes `CronJob` that runs the feature reaper every hour. The job relies on an image that contains the `k8s-feature-reaper` binary.
+
+## Installing the Chart
+
+```
+helm install feature-reaper ./feature-reaper
+```
+
+## Values
+
+| Key | Description | Default |
+|-----|-------------|---------|
+| `image.repository` | Image repository | `ghcr.io/example/feature-reaper` |
+| `image.tag` | Image tag | `latest` |
+| `image.pullPolicy` | Kubernetes image pull policy | `IfNotPresent` |
+| `schedule` | Cron schedule for the job | `"0 * * * *"` |

--- a/charts/feature-reaper/templates/cronjob.yaml
+++ b/charts/feature-reaper/templates/cronjob.yaml
@@ -1,0 +1,15 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: feature-reaper
+spec:
+  schedule: {{ .Values.schedule | quote }}
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: feature-reaper
+              image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+              imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/charts/feature-reaper/values.yaml
+++ b/charts/feature-reaper/values.yaml
@@ -1,0 +1,5 @@
+image:
+  repository: ghcr.io/example/feature-reaper
+  tag: latest
+  pullPolicy: IfNotPresent
+schedule: "0 * * * *"


### PR DESCRIPTION
## Summary
- add a Helm chart under `charts/feature-reaper`
- define CronJob that runs every hour
- document chart values

## Testing
- `go test ./...`
- `go test -run TestIntegrationKind -v` *(skipped: kind not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68474b2f38bc83338284f575a56331e1