### PR TITLE
Expose configurable namespace retention

### DIFF
--- a/charts/feature-reaper/README.md
+++ b/charts/feature-reaper/README.md
@@ -16,3 +16,4 @@ helm install feature-reaper ./feature-reaper
 | `image.tag` | Image tag | `latest` |
 | `image.pullPolicy` | Kubernetes image pull policy | `IfNotPresent` |
 | `schedule` | Cron schedule for the job | `"0 * * * *"` |
+| `maxAge` | Duration before a namespace is eligible for deletion | `72h` |

--- a/charts/feature-reaper/templates/cronjob.yaml
+++ b/charts/feature-reaper/templates/cronjob.yaml
@@ -13,3 +13,5 @@ spec:
             - name: feature-reaper
               image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
               imagePullPolicy: {{ .Values.image.pullPolicy }}
+              args:
+                - --max-age={{ .Values.maxAge }}

--- a/charts/feature-reaper/values.yaml
+++ b/charts/feature-reaper/values.yaml
@@ -3,3 +3,4 @@ image:
   tag: latest
   pullPolicy: IfNotPresent
 schedule: "0 * * * *"
+maxAge: 72h

--- a/integration_test.go
+++ b/integration_test.go
@@ -64,7 +64,7 @@ metadata:
 
 	t.Logf("✅ Namespaces created successfully.")
 	t.Logf("⏳ Running the reaper to clean up old namespaces...")
-	if out, err := exec.Command("go", "run", ".").CombinedOutput(); err != nil {
+	if out, err := exec.Command("go", "run", ".", "--max-age=72h").CombinedOutput(); err != nil {
 		t.Fatalf("failed to run reaper: %v\n%s", err, out)
 	} else {
 		t.Logf("reaper output:\n%s", out)


### PR DESCRIPTION
## Summary
- allow `max-age` to be set via CLI flag
- update cronjob helm chart to pass the flag
- document `maxAge` value in chart README
- adjust integration test to use the new flag

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68475102d0b88333bacd8091bc869a5d