### PR TITLE
Use fake client for integration test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+coverage.out

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,3 @@
 A golang program that runs once and then exits. When it runs it looks at all namespaces in the cluster that its currently in with `labels.isFeature=true` and `annotations.updatedAt` (formatted in `20060102150405`) is more than 72 hours ago - then deletes them without waiting for confirmation.
 
-Run tests with `go test -v ./...`
+Run tests with `make unit-test`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,3 @@
 A golang program that runs once and then exits. When it runs it looks at all namespaces in the cluster that its currently in with `labels.isFeature=true` and `annotations.updatedAt` (formatted in `20060102150405`) is more than 72 hours ago - then deletes them without waiting for confirmation.
 
-You won't be able to run the tests unless you have docker, kubectl, and kind installed.
+Run tests with `go test -v ./...`

--- a/Makefile
+++ b/Makefile
@@ -15,3 +15,8 @@ build-docker:
 load: build-docker
 	kind load docker-image feature-reaper:latest
 
+.phony: unit-test
+unit-test:
+	go clean -testcache
+	go test -v ./... -coverprofile=coverage.out -covermode=atomic
+

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module k8s-feature-reaper
 go 1.21
 
 require (
+	k8s.io/api v0.29.0
 	k8s.io/apimachinery v0.29.0
 	k8s.io/client-go v0.29.0
 )
@@ -10,6 +11,7 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
+	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
 	github.com/go-logr/logr v1.3.0 // indirect
 	github.com/go-openapi/jsonpointer v0.19.6 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
@@ -26,6 +28,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	golang.org/x/net v0.17.0 // indirect
 	golang.org/x/oauth2 v0.10.0 // indirect
@@ -38,7 +41,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/api v0.29.0 // indirect
 	k8s.io/klog/v2 v2.110.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20231010175941-2dd684a91f00 // indirect
 	k8s.io/utils v0.0.0-20230726121419-3b25d923346b // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/emicklei/go-restful/v3 v3.11.0 h1:rAQeMHw1c7zTmncogyy8VvRZwtkmkZ4FxERmMY4rD+g=
 github.com/emicklei/go-restful/v3 v3.11.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
+github.com/evanphx/json-patch v4.12.0+incompatible h1:4onqiflcdA9EOZ4RxV643DvftH5pOlLGNtQ5lPWQu84=
+github.com/evanphx/json-patch v4.12.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/go-logr/logr v1.3.0 h1:2y3SDp0ZXuc6/cjLSZ+Q3ir+QB9T/iG5yYRXqsagWSY=
 github.com/go-logr/logr v1.3.0/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-openapi/jsonpointer v0.19.6 h1:eCs3fxoIi3Wh6vtgmLTOjdhSpiqphQ+DaPn38N2ZdrE=
@@ -61,6 +63,8 @@ github.com/onsi/ginkgo/v2 v2.13.0 h1:0jY9lJquiL8fcf3M4LAXN5aMlS/b2BV86HFFPCPMgE4
 github.com/onsi/ginkgo/v2 v2.13.0/go.mod h1:TE309ZR8s5FsKKpuB1YAQYBzCaAfUgatB/xlT/ETL/o=
 github.com/onsi/gomega v1.29.0 h1:KIA/t2t5UBzoirT4H9tsML45GEbo3ouUnBHsCfD2tVg=
 github.com/onsi/gomega v1.29.0/go.mod h1:9sxs+SwGrKI0+PWe4Fxa9tFQQBG5xSsSbMXOI8PPpoQ=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=

--- a/main.go
+++ b/main.go
@@ -3,20 +3,13 @@ package main
 import (
 	"context"
 	"flag"
-	"fmt"
+	"k8s-feature-reaper/reaper"
 	"log"
 	"time"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-)
-
-const (
-	labelSelector = "isFeature=true"
-	updatedAtKey  = "updatedAt"
-	timeLayout    = "20060102150405"
 )
 
 var maxAge = flag.Duration("max-age", 72*time.Hour, "maximum age of a namespace before deletion")
@@ -48,38 +41,7 @@ func main() {
 		log.Fatalf("failed to create clientset: %v", err)
 	}
 
-	if err := reapNamespaces(ctx, clientset, *maxAge, time.Now()); err != nil {
+	if err := reaper.ReapNamespaces(ctx, clientset, *maxAge, time.Now()); err != nil {
 		log.Fatalf("failed to reap namespaces: %v", err)
 	}
-}
-
-func reapNamespaces(ctx context.Context, client kubernetes.Interface, maxAge time.Duration, now time.Time) error {
-	namespaces, err := client.CoreV1().Namespaces().List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
-	if err != nil {
-		return err
-	}
-
-	for _, ns := range namespaces.Items {
-		ann := ns.Annotations
-		if ann == nil {
-			continue
-		}
-		tsStr, ok := ann[updatedAtKey]
-		if !ok {
-			continue
-		}
-		ts, err := time.Parse(timeLayout, tsStr)
-		if err != nil {
-			log.Printf("namespace %s has invalid updatedAt: %v", ns.Name, err)
-			continue
-		}
-		if now.Sub(ts) > maxAge {
-			if err := client.CoreV1().Namespaces().Delete(ctx, ns.Name, metav1.DeleteOptions{}); err != nil {
-				log.Printf("failed to delete namespace %s: %v", ns.Name, err)
-			} else {
-				fmt.Printf("deleted namespace %s\n", ns.Name)
-			}
-		}
-	}
-	return nil
 }

--- a/reaper/reaper.go
+++ b/reaper/reaper.go
@@ -1,0 +1,52 @@
+package reaper
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	IS_FEATURE_KEY = "isFeature"
+	LABEL_SELECTOR = IS_FEATURE_KEY + "=true"
+	UPDATED_AT_KEY = "updatedAt"
+	TIME_LAYOUT    = "20060102150405"
+)
+
+func ReapNamespaces(ctx context.Context, client kubernetes.Interface, maxAge time.Duration, now time.Time) error {
+	listOpts := metav1.ListOptions{
+		LabelSelector: LABEL_SELECTOR,
+	}
+	namespaces, err := client.CoreV1().Namespaces().List(ctx, listOpts)
+	if err != nil {
+		return err
+	}
+
+	for _, ns := range namespaces.Items {
+		ann := ns.Annotations
+		if ann == nil {
+			continue
+		}
+		tsStr, ok := ann[UPDATED_AT_KEY]
+		if !ok {
+			continue
+		}
+		ts, err := time.Parse(TIME_LAYOUT, tsStr)
+		if err != nil {
+			log.Printf("namespace %s has invalid updatedAt: %v", ns.Name, err)
+			continue
+		}
+		if now.Sub(ts) > maxAge {
+			if err := client.CoreV1().Namespaces().Delete(ctx, ns.Name, metav1.DeleteOptions{}); err != nil {
+				log.Printf("failed to delete namespace %s: %v", ns.Name, err)
+			} else {
+				fmt.Printf("deleted namespace %s\n", ns.Name)
+			}
+		}
+	}
+	return nil
+}

--- a/reaper/reaper_test.go
+++ b/reaper/reaper_test.go
@@ -1,21 +1,23 @@
-package main
+package reaper_test
 
 import (
 	"context"
 	"testing"
 	"time"
 
+	"k8s-feature-reaper/reaper"
+
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 )
 
-func TestReaperWithFakeClient(t *testing.T) {
+func TestReapNamespaces(t *testing.T) {
 	ctx := context.Background()
 	client := fake.NewSimpleClientset()
 
-	oldTS := time.Now().Add(-73 * time.Hour).Format(timeLayout)
-	newTS := time.Now().Add(-1 * time.Hour).Format(timeLayout)
+	oldTS := time.Now().Add(-73 * time.Hour).Format(reaper.TIME_LAYOUT)
+	newTS := time.Now().Add(-1 * time.Hour).Format(reaper.TIME_LAYOUT)
 
 	oldNs := &v1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -24,7 +26,7 @@ func TestReaperWithFakeClient(t *testing.T) {
 				"isFeature": "true",
 			},
 			Annotations: map[string]string{
-				updatedAtKey: oldTS,
+				reaper.UPDATED_AT_KEY: oldTS,
 			},
 		},
 	}
@@ -35,7 +37,7 @@ func TestReaperWithFakeClient(t *testing.T) {
 				"isFeature": "true",
 			},
 			Annotations: map[string]string{
-				updatedAtKey: newTS,
+				reaper.UPDATED_AT_KEY: newTS,
 			},
 		},
 	}
@@ -47,7 +49,7 @@ func TestReaperWithFakeClient(t *testing.T) {
 		t.Fatalf("failed to create new ns: %v", err)
 	}
 
-	if err := reapNamespaces(ctx, client, 72*time.Hour, time.Now()); err != nil {
+	if err := reaper.ReapNamespaces(ctx, client, 72*time.Hour, time.Now()); err != nil {
 		t.Fatalf("reapNamespaces returned error: %v", err)
 	}
 

--- a/reaper/reaper_test.go
+++ b/reaper/reaper_test.go
@@ -23,7 +23,7 @@ func TestReapNamespaces(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "ns-old",
 			Labels: map[string]string{
-				"isFeature": "true",
+				reaper.IS_FEATURE_KEY: "true",
 			},
 			Annotations: map[string]string{
 				reaper.UPDATED_AT_KEY: oldTS,
@@ -34,7 +34,7 @@ func TestReapNamespaces(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "ns-new",
 			Labels: map[string]string{
-				"isFeature": "true",
+				reaper.IS_FEATURE_KEY: "true",
 			},
 			Annotations: map[string]string{
 				reaper.UPDATED_AT_KEY: newTS,


### PR DESCRIPTION
## Summary
- remove Kind-based integration test
- test using client-go's fake client
- refactor main logic into `reapNamespaces` for testability
- tidy modules for new test dependencies

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68478a4feba88333a0b8b36fdfc96bd3